### PR TITLE
Set exit status if child stops via signal

### DIFF
--- a/tests/k5start/basic-t
+++ b/tests/k5start/basic-t
@@ -22,7 +22,7 @@ require "$ENV{C_TAP_SOURCE}/libtest.pl";
 
 # Decide whether we have the configuration to run the tests.
 if (-f "$DATA/test.keytab" and -f "$DATA/test.principal") {
-    plan tests => 89;
+    plan tests => 92;
 } else {
     plan skip_all => 'no keytab configuration';
     exit 0;
@@ -286,6 +286,15 @@ unlink 'krb5cc_test';
     = command ($K5START, '-Uqf', "$DATA/test.keytab", '--', 'sh', '-c',
                'exit 3');
 is ($status, 3, 'k5start of exit 3 returns correct exit status');
+is ($err, '', ' with no errors');
+ok (!-f 'krb5cc_test', ' and the default cache file was not created');
+
+# Test propagation of exit status from a command which is killed by signal.
+unlink 'krb5cc_test';
+($out, $err, $status)
+    = command ($K5START, '-Uqf', "$DATA/test.keytab", '--', 'sh', '-c',
+               'kill $$');
+is ($status, 143, 'k5start of kill $$ returns correct exit status');
 is ($err, '', ' with no errors');
 ok (!-f 'krb5cc_test', ' and the default cache file was not created');
 

--- a/util/command.c
+++ b/util/command.c
@@ -130,6 +130,14 @@ command_finish(pid_t child, int *status)
         return -1;
     if (result == 0)
         return 0;
-    *status = WEXITSTATUS(*status);
+
+    if (status) {
+        if (WIFEXITED(*status))
+            *status = WEXITSTATUS(*status);
+        else if (WIFSIGNALED(*status))
+            // +128 to match exit status set by bash when process is signaled
+            *status = WTERMSIG(*status) + 128;
+    }
+
     return 1;
 }


### PR DESCRIPTION
The current implementation of command_finish always calls WEXITSTATUS,
despite the man page for [waitpid] stating that WEXITSTATUS should only
be used if WIFEXITED returned true.

This change will set the exit status of k5start accordingly by either
using WTERMSIG if WIFSIGNALED returns true, and using WEXITSTATUS if
WIFEXITETED returns true. This means that the user can check the exit
status of the command running under k5start and know if the command
failed. Looking at the following example, in the previous code, the
command would print 0, now it will print 143. This will match the
functionality of bash ([manual]).
```
$ k5start -f ./user.keytab -- sh -c 'kill $$'; echo $?
143
$ sh -c 'kill $$'; echo $?
143
```
This also makes a minor change by only setting the status if it is a
non-null pointer.

[manual]: https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
[waitpid]: https://man7.org/linux/man-pages/man2/wait.2.html